### PR TITLE
Bind AWS CLI version to predefined and a add lot of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Jenkins Agent based on Alpine Linux
 
-Latest build based on image: [`openjdk:8u191-jdk-alpine3.8`](https://hub.docker.com/_/openjdk?tab=tags)
+#### Current versions included in a latest builds:
+
+| Tool          | Version               |
+|---------------|-----------------------|
+| Java JDK      | `8u191-jdk-alpine3.8` |
+| Jenkins Agent | `3.29`                |
+| Docker CLI    | `18.09.1`             |
+| AWS CLI       | `1.16.197`            |
+| Kubectl       | `1.15.0`              |
+| Helm          | `2.14.1`              |
 
 _Here different versions of `Jenkins Agent` images for different tasks_
 
@@ -18,7 +27,6 @@ _Here different versions of `Jenkins Agent` images for different tasks_
 
     This image is similar to the `jnlp-docker-awscli` image but has Kubernetes specific tools `kubectl` and `helm`
 
-
     Running by Docker:
     
     ```shell
@@ -31,7 +39,7 @@ _Here different versions of `Jenkins Agent` images for different tasks_
     Running by Docker Compose:
 
     ```yaml
-    version: '3.3'
+    version: "3.3"
     services:
       jenkins-agent:
         image: binlab/jenkins-agent:jnlp-docker

--- a/jnlp/Dockerfile
+++ b/jnlp/Dockerfile
@@ -20,12 +20,13 @@ RUN addgroup -g ${GID} ${GROUP} \
          -u ${UID} -G ${GROUP} ${USER} \
     && set -x \
     && apk add --update --no-cache \
-       curl \
-       bash \
-       git \
-       openssh-client \
-       openssl \
-       procps \
+         curl \
+         bash \
+         git \
+         openssh-client \
+         openssl \
+         procps \
+    && printf "\n### Installing Jenkins agent v${AGENT_VER} ###\n\n" \
     && curl --create-dirs \
          -sSLo /usr/share/jenkins/slave.jar \
          https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VER}/remoting-${AGENT_VER}.jar \
@@ -35,7 +36,9 @@ RUN addgroup -g ${GID} ${GROUP} \
     && mkdir -p ${AGENT_WORKDIR} \
     && chown -R ${USER}:${GROUP} ${HOME} \
     && chmod +x /usr/local/bin/jenkins-agent \
-    && apk del curl
+    && printf "\n### Cleaning up ###\n\n" \
+    && apk del --purge -v \
+         curl
 
 VOLUME ${HOME}/.jenkins
 VOLUME ${AGENT_WORKDIR}

--- a/jnlp/docker-awscli-kubectl-helm/Dockerfile
+++ b/jnlp/docker-awscli-kubectl-helm/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Mark <mark.binlab@gmail.com>"
 
 ARG AGENT_VER=3.29
 ARG DOCKER_VER=18.09.1
+ARG AWSCLI_VER=1.16.197
 ARG KUBECTL_VER=1.15.0
 ARG HELM_VER=2.14.1
 
@@ -26,13 +27,14 @@ RUN addgroup -g ${GID} ${GROUP} \
          -u ${UID} -G ${GROUP} ${USER} \
     && set -x \
     && apk add --update --no-cache \
-       curl \
-       bash \
-       git \
-       openssh-client \
-       openssl \
-       procps \
-       shadow \
+         curl \
+         bash \
+         git \
+         openssh-client \
+         openssl \
+         procps \
+         shadow \
+    && printf "\n### Installing Jenkins agent v${AGENT_VER} ###\n\n" \
     && curl --create-dirs \
          -sSLo /usr/share/jenkins/slave.jar \
          https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VER}/remoting-${AGENT_VER}.jar \
@@ -41,26 +43,36 @@ RUN addgroup -g ${GID} ${GROUP} \
     && mkdir ${HOME}/.jenkins \
     && mkdir -p ${AGENT_WORKDIR} \
     && chown -R ${USER}:${GROUP} ${HOME} \
-    && apk add --update --no-cache \
-         --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-         aws-cli \
-    && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
-    && tar xzvf docker-${DOCKER_VER}.tgz \
-         --strip 1 \
-         -C /usr/local/bin \
-         docker/docker \
-    && rm docker-${DOCKER_VER}.tgz \
-    && curl -sSL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
-    && chmod 755 /usr/local/bin/kubectl \
-    && curl -sSL https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz -o /tmp/helm-linux-amd64.tar.gz \
-    && tar -xzf /tmp/helm-linux-amd64.tar.gz  -C /tmp \
-    && mv /tmp/linux-amd64/helm  /usr/local/bin/helm \
-    && rm -rf /tmp/linux-amd64 \
     && chmod +x /usr/local/bin/jenkins-agent \
+    && printf "\n### Installing AWS CLI v${AWSCLI_VER} ###\n\n" \
+    && apk add --update --no-cache \
+         python \
+         py-pip \
+    && pip install awscli==${AWSCLI_VER} \
+    && printf "\n### Installing Docker CLI v${DOCKER_VER} ###\n\n" \
+    && curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
+         | tar xzv \
+             --strip 1 \
+             -C /usr/local/bin \
+             docker/docker \
     && chmod +x /usr/local/bin/docker \
     && addgroup -S -g ${DOCKER_GID} ${DOCKER_GROUP} \
     && usermod -a -G ${DOCKER_GROUP} ${USER} \
-    && apk del curl shadow
+    && printf "\n### Installing Kubectl v${KUBECTL_VER} ###\n\n" \
+    && curl -sSL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl \
+         -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && printf "\n### Installing Helm v${HELM_VER} ###\n\n" \
+    && curl -fsSL https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz \
+         | tar xzv \
+             --strip 1 \
+             -C /usr/local/bin \
+             linux-amd64/helm \
+    && chmod +x /usr/local/bin/helm \
+    && printf "\n### Cleaning up ###\n\n" \
+    && apk del --purge -v \
+         shadow \
+         py-pip
 
 VOLUME ${HOME}/.jenkins
 VOLUME ${AGENT_WORKDIR}
@@ -68,5 +80,11 @@ VOLUME ${AGENT_WORKDIR}
 WORKDIR ${HOME}
 
 USER ${USER}
+
+RUN printf "\n### Testing versions, permissions and dependencies of binaries ###\n\n" \
+      && aws --version \
+      && echo "Docker CLI: $(docker --version)" \
+      && echo "Kubectl: $(kubectl version --client --short)" \
+      && echo "Helm: $(helm version --client --short)"
 
 ENTRYPOINT ["jenkins-agent"]

--- a/jnlp/docker-awscli/Dockerfile
+++ b/jnlp/docker-awscli/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Mark <mark.binlab@gmail.com>"
 
 ARG AGENT_VER=3.29
 ARG DOCKER_VER=18.09.1
+ARG AWSCLI_VER=1.16.197
 
 ARG USER=jenkins
 ARG GROUP=jenkins
@@ -24,13 +25,14 @@ RUN addgroup -g ${GID} ${GROUP} \
          -u ${UID} -G ${GROUP} ${USER} \
     && set -x \
     && apk add --update --no-cache \
-       curl \
-       bash \
-       git \
-       openssh-client \
-       openssl \
-       procps \
-       shadow \
+         curl \
+         bash \
+         git \
+         openssh-client \
+         openssl \
+         procps \
+         shadow \
+    && printf "\n### Installing Jenkins agent v${AGENT_VER} ###\n\n" \
     && curl --create-dirs \
          -sSLo /usr/share/jenkins/slave.jar \
          https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VER}/remoting-${AGENT_VER}.jar \
@@ -39,20 +41,25 @@ RUN addgroup -g ${GID} ${GROUP} \
     && mkdir ${HOME}/.jenkins \
     && mkdir -p ${AGENT_WORKDIR} \
     && chown -R ${USER}:${GROUP} ${HOME} \
-    && apk add --update --no-cache \
-         --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-         aws-cli \
-    && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
-    && tar xzvf docker-${DOCKER_VER}.tgz \
-         --strip 1 \
-         -C /usr/local/bin \
-         docker/docker \
-    && rm docker-${DOCKER_VER}.tgz \
     && chmod +x /usr/local/bin/jenkins-agent \
+    && printf "\n### Installing AWS CLI v${AWSCLI_VER} ###\n\n" \
+    && apk add --update --no-cache \
+         python \
+         py-pip \
+    && pip install awscli==${AWSCLI_VER} \
+    && printf "\n### Installing Docker CLI v${DOCKER_VER} ###\n\n" \
+    && curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
+         | tar xzv \
+             --strip 1 \
+             -C /usr/local/bin \
+             docker/docker \
     && chmod +x /usr/local/bin/docker \
     && addgroup -S -g ${DOCKER_GID} ${DOCKER_GROUP} \
     && usermod -a -G ${DOCKER_GROUP} ${USER} \
-    && apk del curl shadow
+    && printf "\n### Cleaning up ###\n\n" \
+    && apk del --purge -v \
+         shadow \
+         py-pip
 
 VOLUME ${HOME}/.jenkins
 VOLUME ${AGENT_WORKDIR}
@@ -60,5 +67,9 @@ VOLUME ${AGENT_WORKDIR}
 WORKDIR ${HOME}
 
 USER ${USER}
+
+RUN printf "\n### Testing versions, permissions and dependencies of binaries ###\n\n" \
+      && aws --version \
+      && echo "Docker CLI: $(docker --version)"
 
 ENTRYPOINT ["jenkins-agent"]

--- a/jnlp/docker/Dockerfile
+++ b/jnlp/docker/Dockerfile
@@ -24,13 +24,14 @@ RUN addgroup -g ${GID} ${GROUP} \
          -u ${UID} -G ${GROUP} ${USER} \
     && set -x \
     && apk add --update --no-cache \
-       curl \
-       bash \
-       git \
-       openssh-client \
-       openssl \
-       procps \
-       shadow \
+         curl \
+         bash \
+         git \
+         openssh-client \
+         openssl \
+         procps \
+         shadow \
+    && printf "\n### Installing Jenkins agent v${AGENT_VER} ###\n\n" \
     && curl --create-dirs \
          -sSLo /usr/share/jenkins/slave.jar \
          https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VER}/remoting-${AGENT_VER}.jar \
@@ -39,17 +40,19 @@ RUN addgroup -g ${GID} ${GROUP} \
     && mkdir ${HOME}/.jenkins \
     && mkdir -p ${AGENT_WORKDIR} \
     && chown -R ${USER}:${GROUP} ${HOME} \
-    && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
-    && tar xzvf docker-${DOCKER_VER}.tgz \
-         --strip 1 \
-         -C /usr/local/bin \
-         docker/docker \
-    && rm docker-${DOCKER_VER}.tgz \
     && chmod +x /usr/local/bin/jenkins-agent \
+    && printf "\n### Installing Docker CLI v${DOCKER_VER} ###\n\n" \
+    && curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
+         | tar xzv \
+             --strip 1 \
+             -C /usr/local/bin \
+             docker/docker \
     && chmod +x /usr/local/bin/docker \
     && addgroup -S -g ${DOCKER_GID} ${DOCKER_GROUP} \
     && usermod -a -G ${DOCKER_GROUP} ${USER} \
-    && apk del curl shadow
+    && printf "\n### Cleaning up ###\n\n" \
+    && apk del --purge -v \
+         shadow
 
 VOLUME ${HOME}/.jenkins
 VOLUME ${AGENT_WORKDIR}
@@ -57,5 +60,8 @@ VOLUME ${AGENT_WORKDIR}
 WORKDIR ${HOME}
 
 USER ${USER}
+
+RUN printf "\n### Testing versions, permissions and dependencies of binaries ###\n\n" \
+      && echo "Docker CLI: $(docker --version)"
 
 ENTRYPOINT ["jenkins-agent"]


### PR DESCRIPTION
- Bind AWS CLI version to predefined in Dockerfile ARG configuration.
- Added steps notification and formatting for the build process.
- Added testing versions, permissions and dependencies of binaries.
- Updated documentation.
- Syntax formatting.
- Other improvements.
- Added next versions to build:
    * Java JDK version: `8u191-jdk-alpine3.8`
    * Jenkins Agent version: `3.29`
    * Docker version: `18.09.1`
    * AWS CLI version: `1.16.197`
    * Kubectl version: `1.15.0`
    * Helm version: `2.14.1`